### PR TITLE
Expose 'ConnectionError' to the public API.

### DIFF
--- a/beluga-mqtt/src/error.rs
+++ b/beluga-mqtt/src/error.rs
@@ -1,4 +1,4 @@
-use rumqttc::ClientError;
+use rumqttc::{ClientError, ConnectionError};
 use tokio::sync::broadcast::error::RecvError;
 
 #[derive(Debug, thiserror::Error)]
@@ -13,6 +13,8 @@ pub enum Error {
     PrivateKey,
     #[error("missing authority")]
     Ca,
+    #[error(transparent)]
+    ConnectionError(#[from] ConnectionError),
     #[error(transparent)]
     Mqtt(#[from] ClientError),
     #[error(transparent)]


### PR DESCRIPTION
During testing, I have caught a lot of connection errors. Till now, the client just continued to poll, instead of just ending execution constantly.

I don't know if it's the best solution, but it works. @scootermon if you know how to improve it, please don't hesitate to create a PR into this PR with corresponding changes.