### PR TITLE
Add a reconnect delay

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Silvestr Predko <silvestr1994@gmail.com>",
     "Simon Berger <simon.berger@inomotech.com>",
 ]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.74"

--- a/beluga-mqtt/Cargo.toml
+++ b/beluga-mqtt/Cargo.toml
@@ -18,7 +18,7 @@ tracing.workspace = true
 [dependencies.tokio]
 workspace = true
 default-features = false
-features = ["rt", "net", "io-util", "sync"]
+features = ["rt", "net", "io-util", "sync", "time"]
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/beluga-mqtt/src/lib.rs
+++ b/beluga-mqtt/src/lib.rs
@@ -97,6 +97,10 @@ impl<'a> MqttClientBuilder<'a> {
 
     /// Sets the minimum delay between reconnection attempts.
     ///
+    /// If set to `Duration::ZERO`, the client will always attempt to reconnect
+    /// immediately without delay, effectively disabling backoff.
+    /// This is not recommended for production use.
+    ///
     /// Defaults to 1 second.
     pub const fn min_reconnect_delay(mut self, time: Duration) -> Self {
         self.min_reconnect_delay = Some(time);
@@ -104,6 +108,9 @@ impl<'a> MqttClientBuilder<'a> {
     }
 
     /// Sets the maximum delay between reconnection attempts.
+    ///
+    /// If set to a value less than the minimum reconnect delay, the minimum
+    /// reconnect delay will be used instead.
     ///
     /// Defaults to 5 minutes.
     pub const fn max_reconnect_delay(mut self, time: Duration) -> Self {
@@ -523,6 +530,7 @@ impl PollContext {
         min_reconnect_delay: Duration,
         max_reconnect_delay: Duration,
     ) -> Self {
+        let max_reconnect_delay = std::cmp::max(min_reconnect_delay, max_reconnect_delay);
         Self {
             client,
             event_loop,

--- a/beluga-mqtt/tests/common/mod.rs
+++ b/beluga-mqtt/tests/common/mod.rs
@@ -120,6 +120,7 @@ pub fn client(
         .thing_name(name)
         .endpoint("127.0.0.1")
         .port(port)
+        .min_reconnect_delay(std::time::Duration::from_millis(10))
         .build()?)
 }
 


### PR DESCRIPTION
Right now beluga immediately tries to reconnect if the connection fails. This PR adds exponential back-off to the reconnect.