### PR TITLE
Update dependencies and disable rustls default features by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,14 +35,13 @@ prost = "0.13"
 rand = "0.9"
 rcgen = "0.13"
 rumqttc = "0.24"
-rustls = "0.23"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.27", features = ["derive"] }
 tempfile = "3"
 thiserror = "2"
 time = "0.3"
-tokio = { version = "1", default-features = false, features = ["full"] }
+tokio = { version = "1", default-features = false }
 tokio-tungstenite = { version = "0.26", default-features = false }
 tokio-util = "0.7"
 toml = "0.8"
@@ -51,6 +50,11 @@ tracing-subscriber = "0.3"
 uuid = "1"
 
 [workspace.dependencies.rumqttd]
-git = "https://github.com/inomotech-foss/rumqtt.git"
+git = "https://github.com/inomotech-foss/rumqtt"
 rev = "d39e1490831c41c90a12705b2a84df9b1a327ff6"
 features = ["verify-client-cert"]
+
+[workspace.dependencies.rustls]
+version = "0.23"
+# we don't want to force-enable aws-lc
+default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,12 +38,12 @@ rumqttc = "0.24"
 rustls = "0.23"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-strum = { version = "0.26", features = ["derive"] }
+strum = { version = "0.27", features = ["derive"] }
 tempfile = "3"
 thiserror = "2"
 time = "0.3"
 tokio = { version = "1", default-features = false, features = ["full"] }
-tokio-tungstenite = { version = "0.25", default-features = false }
+tokio-tungstenite = { version = "0.26", default-features = false }
 tokio-util = "0.7"
 toml = "0.8"
 tracing = "0.1"

--- a/beluga-iot-core/Cargo.toml
+++ b/beluga-iot-core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "beluga-aws-sdk"
+name = "beluga-iot-core"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/beluga-iot-core/Cargo.toml
+++ b/beluga-iot-core/Cargo.toml
@@ -41,6 +41,7 @@ petname.workspace = true
 rcgen.workspace = true
 rustls = { workspace = true, features = ["ring"] }
 time.workspace = true
+tokio = { workspace = true, features = ["full"] }
 toml.workspace = true
 tracing-subscriber.workspace = true
 uuid = { workspace = true, features = ["v4"] }

--- a/beluga-iot-core/examples/job.rs
+++ b/beluga-iot-core/examples/job.rs
@@ -1,4 +1,4 @@
-use beluga_aws_sdk::{details, JobStatus, JobsClient};
+use beluga_iot_core::{details, JobStatus, JobsClient};
 use beluga_mqtt::MqttClientBuilder;
 use tracing::{info, Level};
 

--- a/beluga-iot-core/examples/jobs.rs
+++ b/beluga-iot-core/examples/jobs.rs
@@ -1,6 +1,6 @@
 use core::time::Duration;
 
-use beluga_aws_sdk::{JobStatus, JobsClient};
+use beluga_iot_core::{JobStatus, JobsClient};
 use beluga_mqtt::MqttClientBuilder;
 use tracing::Level;
 

--- a/beluga-iot-core/examples/provision_and_save.rs
+++ b/beluga-iot-core/examples/provision_and_save.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use anyhow::Context;
-use beluga_aws_sdk::provision::{
+use beluga_iot_core::provision::{
     create_certificate_from_csr, register_thing, RegisterThingResponse,
 };
 use beluga_mqtt::MqttClientBuilder;

--- a/beluga-iot-core/examples/provision_with_csr.rs
+++ b/beluga-iot-core/examples/provision_with_csr.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::Context;
-use beluga_aws_sdk::provision::{
+use beluga_iot_core::provision::{
     create_certificate_from_csr, register_thing, RegisterThingResponse,
 };
 use beluga_mqtt::{MqttClientBuilder, QoS};

--- a/beluga-iot-core/examples/provision_with_keys.rs
+++ b/beluga-iot-core/examples/provision_with_keys.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use beluga_aws_sdk::provision::{
+use beluga_iot_core::provision::{
     create_keys_and_certificate, register_thing, RegisterThingResponse,
 };
 use beluga_mqtt::{MqttClientBuilder, QoS};

--- a/beluga-iot-core/examples/start_next_job.rs
+++ b/beluga-iot-core/examples/start_next_job.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use beluga_aws_sdk::{JobStatus, JobsClient};
+use beluga_iot_core::{JobStatus, JobsClient};
 use beluga_mqtt::MqttClientBuilder;
 use tracing::{info, Level};
 

--- a/beluga-iot-core/examples/tunnel_destination.rs
+++ b/beluga-iot-core/examples/tunnel_destination.rs
@@ -1,4 +1,4 @@
-use beluga_aws_sdk::TunnelManager;
+use beluga_iot_core::TunnelManager;
 use beluga_mqtt::MqttClientBuilder;
 use tracing::Level;
 

--- a/beluga-iot-core/examples/update_job_with_details.rs
+++ b/beluga-iot-core/examples/update_job_with_details.rs
@@ -1,6 +1,6 @@
 use core::time::Duration;
 
-use beluga_aws_sdk::{details, JobStatus, JobsClient};
+use beluga_iot_core::{details, JobStatus, JobsClient};
 use beluga_mqtt::MqttClientBuilder;
 use tracing::Level;
 

--- a/beluga-tunnel/src/lib.rs
+++ b/beluga-tunnel/src/lib.rs
@@ -1,4 +1,4 @@
-use bytes::{Buf, BufMut, Bytes};
+use bytes::{Buf, BufMut};
 use futures::{SinkExt, StreamExt};
 use prost::Message as _;
 use proto::{Message as Msg, Type};
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::handshake::client::{generate_key, Request};
-use tokio_tungstenite::tungstenite::protocol::frame::Payload;
 use tokio_tungstenite::tungstenite::{http, Message};
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
@@ -116,9 +115,7 @@ impl Tunnel {
                 };
                 let mut out_payload = bytes::BytesMut::new();
                 serialize_message(&mut out_payload, msg)?;
-                write
-                    .send(Message::Binary(Payload::Owned(out_payload)))
-                    .await?;
+                write.send(Message::Binary(out_payload.freeze())).await?;
                 write.flush().await?;
 
                 service
@@ -139,7 +136,7 @@ impl Tunnel {
                 msg = read.next() => {
                     let bytes = msg
                         .ok_or(Error::WebSocketClosed)?
-                        .map(|msg| ws_payload_to_bytes(msg.into_data()))?;
+                        .map(|msg| msg.into_data())?;
 
                     let messages = process_received_data(bytes)?;
 
@@ -178,7 +175,7 @@ impl Tunnel {
 
                     let mut out_payload = bytes::BytesMut::new();
                     serialize_message(&mut out_payload, msg)?;
-                    write.send(Message::Binary(Payload::Owned(out_payload))).await?;
+                    write.send(Message::Binary(out_payload.freeze())).await?;
                 }
                 _ = close_rx.recv() => {
                     return Err(Error::Service(std::io::Error::other(
@@ -187,14 +184,6 @@ impl Tunnel {
                 }
             }
         }
-    }
-}
-
-fn ws_payload_to_bytes(payload: Payload) -> Bytes {
-    match payload {
-        Payload::Owned(buf) => buf.freeze(),
-        Payload::Shared(buf) => buf,
-        Payload::Vec(v) => Bytes::from(v),
     }
 }
 


### PR DESCRIPTION
Unfortunately rustls pulls in `aws-lc` by default now, which is really annoying because it's a c lib that imposes a lot of limitations on the build system.